### PR TITLE
Expose ports web UI port in docker-compose exemple

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,5 +45,7 @@ services:
     volumes:
       - /path/to/rtorrent:/config
       - /path/to/media/torrents:/data
+    #ports:
+    #  - 127.0.0.1:3000:3000
     networks:
       - rtorrent_network


### PR DESCRIPTION
Hi @Wonderfall!

Thanks for this great new image! I've been using the old one for years. 
I think the Web UI port mapping is missing from the compose example. 

Thanks!
